### PR TITLE
fix(permissions): utilizes single Ability instance for permissions

### DIFF
--- a/imports/casl/Abilities.js
+++ b/imports/casl/Abilities.js
@@ -5,16 +5,18 @@ import { UserRoles } from './UserRoles';
 
 class Abilities {
   static getAbilitiesForUser(user) {
-    return AbilityBuilder.define((can, cannot) => {
-      if (user.roles.includes(UserRoles.ROLE_ADMIN)) {
-        can('access', 'admin-content');
-        can('access', 'manager-content');
-      } else if (user.roles.includes(UserRoles.ROLE_MANAGER)) {
-        can('access', 'manager-content');
-      } else if (user.roles.includes(UserRoles.ROLE_USER)) {
-        // yet no permissions
-      }
-    });
+    const { can, rules } = AbilityBuilder.extract()
+
+    if (user.roles.includes(UserRoles.ROLE_ADMIN)) {
+      can('access', 'admin-content');
+      can('access', 'manager-content');
+    } else if (user.roles.includes(UserRoles.ROLE_MANAGER)) {
+      can('access', 'manager-content');
+    } else if (user.roles.includes(UserRoles.ROLE_USER)) {
+      // yet no permissions
+    }
+
+    return rules
   }
 }
 

--- a/imports/ui/layouts/App.jsx
+++ b/imports/ui/layouts/App.jsx
@@ -18,24 +18,8 @@ class App extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      currentUser: null,
-      abilities: null,
+      abilities: this.createAbility(),
     };
-  }
-
-  static getDerivedStateFromProps(props, state) {
-    let newState = {
-      abilities: state.abilities,
-    };
-    if (props.currentUser === state.currentUser && state.abilities === null) {
-      newState.currentUser = state.currentUser;
-      newState.abilities = new Ability();
-    } else if (props.currentUser !== state.currentUser && props.currentUser !== null) {
-      newState.currentUser = props.currentUser;
-      newState.abilities = new Ability(props.currentUser.abilities);
-    }
-    newState.abilities.update();
-    return newState;
   }
 
   renderRedirect(location) {
@@ -63,6 +47,28 @@ class App extends Component {
       Meteor.logout();
     }
   };
+
+  updateAbilities() {
+    const { currentUser } = this.props
+
+    if (currentUser) {
+      this.state.abilities.update(currentUser.abilities)
+    }
+  }
+
+  createAbility() {
+    const { currentUser } = this.props
+
+    return new Ability(currentUser ? currentUser.abilities : [])
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.currentUser !== prevProps.currentUser) {
+      this.setState({ abilities: this.createAbility() })
+      // or you can reuse existing `Ability` instance
+      // this.updateAbilities()
+    }
+  }
 
   renderContent(location) {
     return (

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.5",
     "@casl/ability": "2.3.0",
-    "@casl/react": "0.7.0",
+    "@casl/react": "^1.0.3",
     "antd": "^3.15.1",
     "bcrypt": "^3.0.0",
     "classnames": "^2.2.6",

--- a/server/main.js
+++ b/server/main.js
@@ -105,7 +105,7 @@ if (Meteor.isServer) {
     user.createdOn = new Date();
 
     // Resolve and store abilities for user during creation
-    user.abilities = Abilities.getAbilitiesForUser(user).rules;
+    user.abilities = Abilities.getAbilitiesForUser(user);
 
     // We still want the default hook's 'profile' behavior.
     if (options.profile) {


### PR DESCRIPTION
Few notes:
1. You use old versions of `@casl/react` and `@casl/ability`. I updated `@casl/react` to the latest one
2. There are 2 way you can achieve what you want
    * reuse 1 `Ability` instance in the app and update its abilities by calling `update` method (https://stalniy.github.io/casl/abilities/2017/07/20/define-abilities.html#update-abilities)
   * create a new instance every time use is changed
   
   I showed 2 ways how to do this (in `componentDidUpdate`). Which one to choose is up to you and your believes (immutable vs mutable) :)
3. You don't need `getDerivedStateFromProps` (read [here](https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops))
4. I used `AbilityBuilder.extract` instead of `AbilityBuilder.define`, it just creates a list of rules (the latest one creates `Ability` instance)